### PR TITLE
aからhaginoippeiに変更

### DIFF
--- a/test.rb
+++ b/test.rb
@@ -1,1 +1,1 @@
-puts("a")
+puts("ippeihagino")


### PR DESCRIPTION
## 本のページ

なし
## 概要(why?)

putsの中身をaからhaginoippeiに変更
## 技術的変更点概要(how)
- putsメソッドの引数の””の文字列をaからhaginoippeiに変更
## 見所
- putsの中身
## テスト項目
- [x] ruby test.rbの実行結果がhaginoippeiになっている
## 特記事項

特に無し
## どのURLを参考にしたか？

http://www.backlog.jp/git-guide/reference/remote.html
http://qiita.com/Id_Seth/items/b684cfabe0f2fde0c67b
